### PR TITLE
Add mobile input

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
           </div>
         </div>
       </div>
+      <div class="mobile-input">
+      </div>
     </div>
   </div>
 

--- a/scripts.js
+++ b/scripts.js
@@ -174,6 +174,7 @@ const keyCodes = {
 };
 
 const body = document.querySelector('body');
+const mobileInputDiv = document.querySelector('.mobile-input');
 
 const canvas = document.querySelector('canvas');
 const ctx = canvas.getContext('2d');
@@ -191,6 +192,19 @@ function drawNumberToCanvas(number) {
   link.type = 'image/x-icon';
   link.href = data;
 }
+
+document.addEventListener('touchstart', function(e) {
+  if (document.querySelector('.mobile-input input') !== null) return;
+
+  const input = document.createElement('input');
+  input.setAttribute('type', 'text');
+  mobileInputDiv.appendChild(input);
+
+  // For some reason, the focus is immediately lost unless there is a delay on setting the focus
+  setTimeout(function() {
+    input.focus();
+  }, 100);
+});
 
 body.onkeydown = function(e) {
   if (!e.metaKey) {
@@ -223,6 +237,12 @@ body.onkeydown = function(e) {
     newCodeText = '<a href="https://w3c.github.io/uievents-code/#table-key-code-special" target="_blank">Unidentified</a>';
   } else {
     newCodeText = e.code || '';
+  }
+
+  // Clear input if manually entered
+  const mobileInput = document.querySelector('.mobile-input input');
+  if (mobileInput !== null) {
+    mobileInput.value = '';
   }
 
   document.querySelector('.item-key .main-description').innerHTML = newKeyText;

--- a/style.css
+++ b/style.css
@@ -137,6 +137,17 @@
   height: 4rem;
   margin: 10px;
   font-size: 4rem;
+  border: 1px solid #DADADA;
+  border-radius: 4px;
+  box-shadow: 0 14px 26px rgba(0,0,0,0.04);
+  transition: all 0.3s ease-out;
+}
+
+.mobile-input input:focus {
+  outline: none;
+  transform: translateY(-5px) scale(1.005) translateZ(0);
+  box-shadow: 0 24px 36px rgba(0,0,0,0.11),
+    0 24px 46px rgba(220, 233, 255, 0.48);
 }
 
 @media (min-width: 601px) and (max-width: 980px) {

--- a/style.css
+++ b/style.css
@@ -132,6 +132,13 @@
   color: #ccc;
 }
 
+.mobile-input input {
+  width: calc(100% - 20px);
+  height: 4rem;
+  margin: 10px;
+  font-size: 4rem;
+}
+
 @media (min-width: 601px) and (max-width: 980px) {
   body{
     overflow-y: auto;


### PR DESCRIPTION
Adds an input that is created/focused on the `touchstart` event, to allow the site to work on mobile, based on 180.

This closes #180