### PR TITLE
[UTI-2608] Team name change to Marketing Tools 2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @toptal/ext-utilities-eng
+* @toptal/marketing-tools-2-eng


### PR DESCRIPTION
[UTI-2608](https://toptal-core.atlassian.net/browse/UTI-2608)

### Description

Changing the team name from Utilities to Marketing Tools 2.

Code owners will be `toptal/marketing-tools-2-eng`. Jenkins folder should be `marketing-tools-2`.
