### PR TITLE
modify getKeyCodeEvent to match better. Fixes 336

### DIFF
--- a/lib/utils/get-key-code-event.ts
+++ b/lib/utils/get-key-code-event.ts
@@ -6,6 +6,6 @@ export const getKeyCodeEvent = (
 ): KeyCodeEvent | undefined => {
   return keyCodeEventValues.find(
     keyCodeEvent =>
-      keyCodeEvent.code === keyCode.code && keyCodeEvent.key === keyCode.key
+      keyCodeEvent.code === keyCode.code || keyCodeEvent.key === keyCode.key
   )
 }


### PR DESCRIPTION
When toptal updated the codebase, the logic for finding the keycode was too strict. It was expecting both the .code and the .key - so that filtered out descriptions on keys without one of those values. Importantly this was excluding every single modifier key - like `Shift + a` being code `A`.

Easy fix - it should a bit more relaxed on finding. The code first, if not, the key.

Fixes #334 