### PR TITLE
fix(keycodes): correct MetaRight and ContextMenu descriptions

### DIFF
--- a/lib/keycodes/with-events.ts
+++ b/lib/keycodes/with-events.ts
@@ -780,7 +780,7 @@ export const keyCodesWithEvents: Record<string, KeyCodeEvent> = {
     ctrlKey: false,
     metaKey: true,
     shiftKey: true,
-    description: 'Right Windows',
+    description: 'Right Windows / Right ⌘',
     unicode: '⌘ ⊞',
     path: '/meta-right'
   },
@@ -794,7 +794,7 @@ export const keyCodesWithEvents: Record<string, KeyCodeEvent> = {
     ctrlKey: false,
     metaKey: false,
     shiftKey: false,
-    description: 'Windows Menu / Right ⌘',
+    description: 'Windows Menu',
     unicode: '▤',
     path: '/context-menu'
   },


### PR DESCRIPTION
This PR fixes two inconsistencies in the keyboard key descriptions:

1. **MetaRight missing "Right ⌘"**: While MetaLeft correctly includes "Left ⌘" in its description, MetaRight was missing the corresponding "Right ⌘" label.

2. **ContextMenu incorrectly labeled**: The ContextMenu key currently shows "Right ⌘", but this doesn't match the physical layout of Mac keyboards

These changes improve accuracy and maintain consistency across the keyboard layout descriptions.

### How to test
- Run the development server
- Open the app in a browser
- Verify MetaRight now includes "Right ⌘" in its description card in the UI when pressed and in its description column in the table
- Verify ContextMenu no longer includes "Right ⌘" in its description card in the UI when pressed and in its description column in the table

### Acceptance Criteria
- [x] MetaRight description includes "Right ⌘"
- [x] ContextMenu description does not include "Right ⌘"

### Pre-merge checklist
- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `main` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).

### Related Issues
Fixes #345 