### PR TITLE
chore(security): secret scanning + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      exclude:
+        - toptal/*
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      exclude:
+        - toptal/*

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,8 @@
+name: Secret Scan
+
+on:
+  pull_request:
+
+jobs:
+  call_secret_scanning:
+    uses: toptal/actions/.github/workflows/security-scan.yml@v3.6.3


### PR DESCRIPTION
Automated SecOps readiness fix against the Code Readiness Security Checklist.

- Adds `.github/workflows/security-scan.yml` — gitleaks secret scanning on every PR via the standard reusable workflow `toptal/actions/.github/workflows/security-scan.yml@v3.6.3`.
- Adds `.github/dependabot.yml` with a 7-day cooldown (`default-days: 7`) so updates skip versions younger than 7 days.

Ref: https://toptal-core.atlassian.net/wiki/spaces/I/pages/5939462170